### PR TITLE
Changed logger file format for git ignore

### DIFF
--- a/code/quadratic-equation-solver/Infrastructure/src/test/java/unn/agile/SolvingQuadraticEquation/infrastructure/FileLoggerTests.java
+++ b/code/quadratic-equation-solver/Infrastructure/src/test/java/unn/agile/SolvingQuadraticEquation/infrastructure/FileLoggerTests.java
@@ -3,9 +3,6 @@ package unn.agile.SolvingQuadraticEquation.infrastructure;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
@@ -14,13 +11,15 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 
 public class FileLoggerTests {
     private Pattern messageLogPattern;
     private Matcher messageLogMatcher;
     private static final String FILE_NAME_FOR_LOG =
-            "./TxtLogger_Tests-quadraticEquationSolver.makeLog";
+            "./TxtLogger_Tests-quadraticEquationSolver.log";
     private FileQuadraticEquationSolverLogger fileLogger;
 
     @Before

--- a/code/quadratic-equation-solver/Infrastructure/src/test/java/unn/agile/SolvingQuadraticEquation/infrastructure/ViewModelWithTxtLoggerTests.java
+++ b/code/quadratic-equation-solver/Infrastructure/src/test/java/unn/agile/SolvingQuadraticEquation/infrastructure/ViewModelWithTxtLoggerTests.java
@@ -9,7 +9,7 @@ public class ViewModelWithTxtLoggerTests extends ViewModelTests {
     public void setUp() {
         FileQuadraticEquationSolverLogger logger =
                 new FileQuadraticEquationSolverLogger(
-                        "./ViewModel_with_FileLogger_Tests-quadraticEquationSolver.makeLog");
+                        "./ViewModel_with_FileLogger_Tests-quadraticEquationSolver.log");
         super.setExteriorlViewModel(new ViewModel(logger));
     }
 }


### PR DESCRIPTION
В задаче quadratic-equation-solver, после прохождения инфраструктурных тестов, как и нужно создавались логи, но их формат был *.makeLog, я изменил на *.log, поскольку он включен в .gitignore. После каждой проверки gradle check, приходилось удалять логи.