### PR TITLE
Gitter badge link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Спецкурс "Agile Development"
 
-[![Join the chat][gitter-badge]](gitter)
+[![Join the chat][gitter-badge]][gitter]
 [![Build Status][travis-badge]][travis]
-[![Coverage Status][coveralls-badge]](coveralls)
+[![Coverage Status][coveralls-badge]][coveralls]
 
   - Нижегородский государственный университет имени Н.И. Лобачевского (ННГУ)
     - Институт ИТММ, кафедра МОСТ


### PR DESCRIPTION
Отправляет на `blob/master/gitter`

![image](https://user-images.githubusercontent.com/16756393/47117607-1c1d1d00-d265-11e8-8123-2d0a09ccce23.png)

