### PR TITLE
Поправил предупреждение от Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ tasks.cpdCheck {
     def reportName = temporaryDir.getAbsolutePath() + '/cpd.xml'
     reports {
         xml.enabled = true
-        xml.destination = reportName
+        xml.destination = file(reportName)
     }
 
     doFirst {
@@ -175,7 +175,7 @@ task jacocoRootReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
         html.enabled = true
         xml.enabled = true
         csv.enabled = false
-        xml.destination = "${buildDir}/reports/jacoco/test/jacocoTestReport.xml"
+        xml.destination = file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml")
     }
 
     afterEvaluate {


### PR DESCRIPTION
В этом коммите поправил предупреждение от Gradle об использовании
устаревшего метода, который будет удален в мажорном обновлении - Gradle 5.

[Пример предупреждения](https://travis-ci.org/UNN-VMK-Software/agile-course-practice/builds/444453103#L572):
```
...
The command "gradle -v" exited with 0.
67.90s$ gradle check jacocoTestReport
Picked up _JAVA_OPTIONS: -Xmx2048m -Xms512m
The ConfigurableReport.setDestination(Object) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use the method ConfigurableReport.setDestination(File) instead.
	at build_5mj90uwdpq2t3g1morxaj1g08$_run_closure5$_closure9.doCall(/home/travis/build/UNN-VMK-Software/agile-course-practice/build.gradle:41)
:cpdCheck
...
```
[После исправления](https://travis-ci.org/UNN-VMK-Software/agile-course-practice/builds/444458096?utm_source=github_status&utm_medium=notification):
```
...
The command "gradle -v" exited with 0.
$ gradle check jacocoTestReport
Picked up _JAVA_OPTIONS: -Xmx2048m -Xms512m
:cpdCheck
...
```
Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>