### PR TITLE
Fix checkstyle config for windows.

### DIFF
--- a/config/checkstyle/main.xml
+++ b/config/checkstyle/main.xml
@@ -41,7 +41,9 @@
 
     <!-- Checks whether files end with a new line.                        -->
     <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
-    <module name="NewlineAtEndOfFile"/>
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf" />
+    </module>
 
     <!-- Checks for Size Violations.                    -->
     <!-- See http://checkstyle.sf.net/config_sizes.html -->

--- a/config/checkstyle/test.xml
+++ b/config/checkstyle/test.xml
@@ -41,7 +41,9 @@
 
     <!-- Checks whether files end with a new line.                        -->
     <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
-    <module name="NewlineAtEndOfFile"/>
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf" />
+    </module>
 
     <!-- Checks for Size Violations.                    -->
     <!-- See http://checkstyle.sf.net/config_sizes.html -->


### PR DESCRIPTION
Checkstyle failed for me because by default it uses system
default convention of line endings. I was working on
windows and the project was using unix-style line endings.

Docs:
http://checkstyle.sourceforge.net/config_misc.html#NewlineAtEndOfFile_Properties